### PR TITLE
release version 1.0

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,32 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Add the General registry via Git"
+        run: |
+          import Pkg
+          ENV["JULIA_PKG_SERVER"] = ""
+          Pkg.Registry.add("General")
+        shell: julia --color=yes {0}
+      - name: "Install CompatHelper"
+        run: |
+          import Pkg
+          name = "CompatHelper"
+          uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
+          version = "3"
+          Pkg.add(; name, uuid, version)
+        shell: julia --color=yes {0}
+      - name: "Run CompatHelper"
+        run: |
+          import CompatHelper
+          CompatHelper.main()
+        shell: julia --color=yes {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+          # COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DBFTables"
 uuid = "75c7ada1-017a-5fb6-b8c7-2125ff2d6c93"
-version = "0.2.3"
+version = "1.0.0"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -9,7 +9,7 @@ WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 
 [compat]
 Tables = "0.2, 1"
-WeakRefStrings = "0.6"
+WeakRefStrings = "0.6, 1"
 julia = "1.0"
 
 [extras]

--- a/src/DBFTables.jl
+++ b/src/DBFTables.jl
@@ -22,7 +22,7 @@ struct Header
     mdx::Bool
     lang_id::UInt8
     fields::Vector{FieldDescriptor}
-    fieldcolumns::Dict{Symbol, Int}
+    fieldcolumns::Dict{Symbol,Int}
 end
 
 "Struct representing the DBF Table"
@@ -97,7 +97,7 @@ function Header(io::IO)
     fields = FieldDescriptor[]
 
     # use Dict for quicker column index lookup
-    fieldcolumns = Dict{Symbol, Int}()
+    fieldcolumns = Dict{Symbol,Int}()
     col = 1
     while !eof(io)
         field = read_dbf_field(io)
@@ -146,8 +146,7 @@ function dbf_value(::Type{Bool}, str::AbstractString)
     end
 end
 
-dbf_value(T::Union{Type{Int},Type{Float64}}, str::AbstractString) =
-    miss(tryparse(T, str))
+dbf_value(T::Union{Type{Int},Type{Float64}}, str::AbstractString) = miss(tryparse(T, str))
 # String to avoid returning SubString{String}
 function dbf_value(::Type{String}, str::AbstractString)
     stripped = rstrip(str)
@@ -221,10 +220,8 @@ function Base.NamedTuple(row::Row)
     ncol = length(fields)
     rowidx = getrow(row)
     @inbounds record = @view str[:, rowidx]
-    @inbounds prs = (fields[col].name => dbf_value(
-        fields[col].type,
-        record[col],
-    ) for col = 1:ncol)
+    @inbounds prs =
+        (fields[col].name => dbf_value(fields[col].type, record[col]) for col = 1:ncol)
     return (; prs...)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,10 +38,8 @@ row, st = iterate(dbf)
     @testset "show" begin
         @test sprint(show, row) === sprint(show, NamedTuple(row))
         # use replace to update to julia 1.4 union printing
-        @test replace(sprint(
-            show,
-            dbf,
-        ), r"\} +"=>"}") === "DBFTables.Table with 7 rows and 6 columns\nTables.Schema:\n :CHAR     Union{Missing, String}\n :DATE     Union{Missing, String}\n :BOOL     Union{Missing, Bool}\n :FLOAT    Union{Missing, Float64}\n :NUMERIC  Union{Missing, Float64}\n :INTEGER  Union{Missing, $Int}\n"
+        @test replace(sprint(show, dbf), r"\} +" => "}") ===
+              "DBFTables.Table with 7 rows and 6 columns\nTables.Schema:\n :CHAR     Union{Missing, String}\n :DATE     Union{Missing, String}\n :BOOL     Union{Missing, Bool}\n :FLOAT    Union{Missing, Float64}\n :NUMERIC  Union{Missing, Float64}\n :INTEGER  Union{Missing, $Int}\n"
     end
 
     @testset "iterate" begin


### PR DESCRIPTION
Fixes #15

- use import to protect breakage from new exports
- add CompatHelper
- WeakRefStrings 1 compat, set version to 1.0.0
- run JuliaFormatter

So 1.0 does not have any breaking changes compared to 0.2, but since I don't see any on the near horizon we may as well tag 1.0.
