### PR TITLE
Reading/writing updates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DBFTables"
 uuid = "75c7ada1-017a-5fb6-b8c7-2125ff2d6c93"
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/DBFTables.jl
+++ b/src/DBFTables.jl
@@ -129,7 +129,7 @@ end
 julia_value(o::FieldDescriptor, s::AbstractString) = julia_value(o.type, Val(o.dbf_type), s::AbstractString)
 
 function julia_value(::Type{String}, ::Val{'C'}, s::AbstractString)
-    s2 = rstrip(s)
+    s2 = strip(s)
     isempty(s2) ? missing : String(s2)
 end
 function julia_value(::Type{Date}, ::Val{'D'}, s::AbstractString)

--- a/src/DBFTables.jl
+++ b/src/DBFTables.jl
@@ -87,7 +87,7 @@ dbf_value(field::FieldDescriptor, val) = dbf_value(Val(field.dbf_type), field.le
 
 # String (or any other type that gets mapped to 'C')
 function dbf_value(::Val{'C'}, len::UInt8, x)
-    out = replace(rpad(x, len), !isascii => ' ')
+    out = replace(rpad(x, len), !isascii => x -> '_' ^ textwidth(x))
     length(out) > 254 ? out[1:254] : out
 end
 dbf_value(::Val{'C'}, len::UInt8, ::Missing) = ' ' ^ len

--- a/src/DBFTables.jl
+++ b/src/DBFTables.jl
@@ -108,7 +108,7 @@ dbf_value(::Val{'N'}, ::UInt8, ::Missing) = ' ' ^ 20
 dbf_value(::Val{'D'}, ::UInt8, x::Date) = Dates.format(x, "yyyymmdd")
 dbf_value(::Val{'D'}, ::UInt8, ::Missing) = ' ' ^ 8
 
-dbf_value(::Val, ::UInt8, x) = error("No known conversion from Julia to DBF: $x.")
+dbf_value(::Val, ::UInt8, x) = error("This should be unreachable.  No known conversion from Julia to DBF: $x.")
 
 #-----------------------------------------------------------------------# conversions: DBF-to-Julia
 "Get the Julia type from the DBF type code and the decimal count"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,8 @@ row, st = iterate(dbf)
         @test roundtrip([(; x=1.0), (;x=missing)])
         @test roundtrip([(; x=missing), (; x=missing)])
 
-        @test_warn "Data will be stored as the DBF character data type" DBFTables.write(tempname(), [(; x = rand(10))])
+        @test_warn "No DBF type" DBFTables.write(tempname(), [(; x = rand(1))])
+        @test_warn "truncated to 254 characters" DBFTables.write(tempname(), [(; x = rand(999))])
 
         # Base.write for DBFTables.Table
         file = joinpath(tempdir(), "test.dbf")


### PR DESCRIPTION
This PR:

1. Fixes reading from DBF data types that do not convert to string (`I`, `O`, and `+`).  
2. Limits writing to the DBF data types `C (AbstractString), L (Bool), N (Integer and AbstractFloat), and D (Date)`.
  a.  Any other Julia type will be saved as `'C'` using `string(x)` rather than dropping data.

The rationale is to:

1. Support as many DBF versions as possible in reading.
2. Allow any DBF reader outside Julia to be able to read DBFTables-written files.