### PR TITLE
Jd/dev

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DBFTables"
 uuid = "75c7ada1-017a-5fb6-b8c7-2125ff2d6c93"
-version = "1.2.1"
+version = "1.2.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "1.2.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 

--- a/src/DBFTables.jl
+++ b/src/DBFTables.jl
@@ -272,7 +272,7 @@ end
 
 
 # ref: https://www.clicketyclick.dk/databases/xbase/format/dbf.html
-function Base.Base.write(io::IO, h::Header)
+function Base.write(io::IO, h::Header)
     out = 0
     out += Base.write(io, h.version)  # 0
     yy = UInt8(year(h.last_update) - 1900)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,4 +118,16 @@ row, st = iterate(dbf)
         @test !DBFTables.isdeleted(dbf, 3)
     end
 
+    @testset "Numeric 20-character Limit Nonsense" begin
+        big = BigInt(99999_99999_99999_99999)
+        @test DBFTables.dbf_value(Val('N'), 0x01, big) == string(big)
+        @test_throws Exception DBFTables.dbf_value(Val('N'), 0x01, big + 1)
+
+        negbig = -BigInt(99999_99999_99999_9999)  # one less digit for the minus sign
+        @test DBFTables.dbf_value(Val('N'), 0x01, negbig) == string(negbig)
+        @test_throws Exception DBFTables.dbf_value(Val('N'), 0x01, negbig - 1)
+
+        @test_warn r"DBF limitation" DBFTables.dbf_value(Val('N'), 0x01, prevfloat(Inf))
+        @test_warn r"DBF limitation" DBFTables.dbf_value(Val('N'), 0x01, nextfloat(-Inf))
+    end
 end  # testset "DBFTables"


### PR DESCRIPTION
Okay, this is the last time I plan on touching this package for a good long while.  Changes to writing 'N' (Numeric) values:

1. Integers outside of the 20-character limit will error (currently a warning and truncated to (+/-) 9999...).
2. Smarter truncation of AbstractFloats to reduce precision vs. clamping to a value.

Technically I suppose 1 is breaking, but I'd opt for a patch version bump.  