### PR TITLE
Improve column read speed by removing type instability

### DIFF
--- a/src/DBFTables.jl
+++ b/src/DBFTables.jl
@@ -452,8 +452,7 @@ function Base.getproperty(dbf::Table, name::Symbol)
     nrow = header.records
     @inbounds field = getfields(dbf)[col]
     str = getstrings(dbf)
-    @inbounds colarr = [julia_value(field, str[col, i]) for i = 1:nrow]
-    return colarr
+    return @inbounds Union{field.type, Missing}[julia_value(field, str[col, i]) for i = 1:nrow]
 end
 
 

--- a/src/DBFTables.jl
+++ b/src/DBFTables.jl
@@ -452,7 +452,9 @@ function Base.getproperty(dbf::Table, name::Symbol)
     nrow = header.records
     @inbounds field = getfields(dbf)[col]
     str = getstrings(dbf)
-    return @inbounds Union{field.type, Missing}[julia_value(field, str[col, i]) for i = 1:nrow]
+    ft = field.type
+    fv = Val{field.dbf_type}()
+    return @inbounds Union{field.type, Missing}[julia_value(ft, fv, str[col, i]) for i = 1:nrow]
 end
 
 

--- a/src/DBFTables.jl
+++ b/src/DBFTables.jl
@@ -452,9 +452,9 @@ function Base.getproperty(dbf::Table, name::Symbol)
     nrow = header.records
     @inbounds field = getfields(dbf)[col]
     str = getstrings(dbf)
-    ft = field.type
-    fv = Val{field.dbf_type}()
-    return @inbounds Union{field.type, Missing}[julia_value(ft, fv, str[col, i]) for i = 1:nrow]
+    FT = field.type
+    FV = Val{field.dbf_type}()
+    return @inbounds Union{FT, Missing}[julia_value(FT, FV, str[col, i]) for i = 1:nrow]
 end
 
 


### PR DESCRIPTION
This improves the speed of a column re-materialization which has to be done using Tables.jl from 160 ms to 10 ms.

Benchmark:
```julia
using Shapefile, GeometryOps, DataFrames, BenchmarkTools


shp_file = "/Users/anshul/Downloads/ne_10m_admin_0_countries (1)/ne_10m_admin_0_countries.shp"
table = Shapefile.Table(shp_file)
df = DataFrame(table) # convert everything including the DBFTable to a DataFrame

_scale_by_5(x) = x .* 5
@benchmark GeometryOps.transform($_scale_by_5, $table) # 160 ms before, 13 ms after
@benchmark GeometryOps.transform($_scale_by_5, $df)    # 7 ms
```